### PR TITLE
Fix title not being localized

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -8,9 +8,18 @@ import '../globals.css'
 
 const inter = Mulish({ subsets: ['latin'] })
 
-export const metadata: Metadata = {
-  title: `${SITE.NAME} - ${SITE.DESCRIPTION}`,
-  description: SITE.DESCRIPTION,
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: LocalesType }
+}): Promise<Metadata> {
+  return {
+    title: `${SITE.NAME} - ${SITE.DESCRIPTION[params.locale]}`,
+    description: SITE.DESCRIPTION[params.locale],
+    alternates: {
+      canonical: `/${params.locale}`,
+    },
+  }
 }
 
 export default async function RootLayout(props: Readonly<PageProps>) {

--- a/constants/global.ts
+++ b/constants/global.ts
@@ -1,9 +1,12 @@
 export const INVALIDATE_INTERVAL: number = 3600
 export const SITE = {
   NAME: 'Brinca',
-  DESCRIPTION: 'Sua comunidade Brasileira em Ottawa-Gatineau!',
+  DESCRIPTION: {
+    en: 'Your Brazilian community in Ottawa-Gatineau!',
+    pt_br: 'Sua comunidade Brasileira em Ottawa-Gatineau!',
+  },
   LOGIN_URL: 'https://brinca-admin.vercel.app',
-  DEFAULT_LOCALE: 'pt_br',
+  DEFAULT_LOCALE: 'en',
 }
 
 export const MESSAGES = {


### PR DESCRIPTION
This pull request introduces localization support for metadata and updates the default locale for the site. The most important changes include modifying the metadata generation function to support multiple locales and restructuring the site description to accommodate translations.

### Localization support:

* `app/[locale]/layout.tsx`: Replaced the static `metadata` object with an `async generateMetadata` function that dynamically generates localized metadata based on the `locale` parameter. This includes localized `title`, `description`, and a canonical URL for each locale. ([app/[locale]/layout.tsxL11-R22](diffhunk://#diff-44ca66e460fac15e804a2ab56f6038ef2dd0a231881294f0a3895f9ad7624c58L11-R22))

* [`constants/global.ts`](diffhunk://#diff-865abaf6df2bb45a53444d92e564b037b3c04ff429094488c79ee79fe307c09fL4-R9): Updated the `SITE.DESCRIPTION` to be an object with translations for `en` and `pt_br` locales. Adjusted the `DEFAULT_LOCALE` to `en` instead of `pt_br`.