### PR TITLE
Make SiteFooter locale-aware and load pages client-side

### DIFF
--- a/src/app/(frontend)/[locale]/layout.tsx
+++ b/src/app/(frontend)/[locale]/layout.tsx
@@ -39,7 +39,7 @@ export default async function RootLayout(props: {
             <SiteHeader locale={locale} />
           </React.Suspense>
           <main>{children}</main>
-          <SiteFooter />
+          <SiteFooter locale={locale} />
         </SlugProvider>
       </body>
     </html>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,12 +1,53 @@
+'use client'
+
 import Link from 'next/link'
+import React from 'react'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 
-export default function SiteFooter() {
+export default function SiteFooter({ locale }: { locale: string }) {
+  const [pages, setPages] = React.useState<any[]>([])
+
+  React.useEffect(() => {
+    let mounted = true
+
+    ;(async () => {
+      try {
+        const res = await fetch(`/api/public/pages?locale=${encodeURIComponent(locale)}`)
+        if (!res.ok) return
+        const json = await res.json()
+        if (mounted) setPages(json.pages || [])
+      } catch (e) {
+        // ignore
+      }
+    })()
+
+    return () => {
+      mounted = false
+    }
+  }, [locale])
+
   return (
     <footer className="site-footer mt-12 py-4">
       <Separator className="mb-4" />
-      <div className="site-footer-inner max-w-4xl mx-auto px-8 flex justify-end">
+      <div className="site-footer-inner max-w-4xl mx-auto px-8 flex items-center justify-between gap-4">
+        <div className="pages-list flex items-center" aria-hidden={!locale}>
+          {pages.length > 0 && (
+            <div className="pages-scroll flex gap-2 overflow-x-auto py-1">
+              {pages.map((p: any) => {
+                const slug = typeof p.slug === 'string' ? p.slug : p.slug?.[locale]
+                return (
+                  <Button key={p.id} asChild variant="ghost" size="sm">
+                    <Link href={`/${locale}/${slug}`}>
+                      {p.title?.[locale] ?? p.title ?? 'Page'}
+                    </Link>
+                  </Button>
+                )
+              })}
+            </div>
+          )}
+        </div>
+
         <Button asChild variant="ghost" size="sm">
           <Link href="/admin">Dashboard</Link>
         </Button>


### PR DESCRIPTION
### Motivation
- Allow the footer to display localized public pages and links for the current `locale` by fetching pages at runtime rather than embedding static links.

### Description
- Pass `locale` from the route `RootLayout` into `SiteFooter` and update the call site to `SiteFooter locale={locale}`.
- Convert `SiteFooter` into a client component by adding `'use client'` and importing `React`, then adding local state and a `useEffect` to fetch `/api/public/pages?locale=${encodeURIComponent(locale)}`.
- Render a horizontally-scrollable list of page buttons using the locale-specific `slug` and `title` when available, while preserving the existing `Dashboard` link and updating footer layout classes.
- Use a mounted flag to avoid state updates after unmount and ignore fetch errors silently.

### Testing
- Ran TypeScript check with `tsc --noEmit`, which completed successfully.
- Performed a local Next.js build with `next build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12b722f1c8328bd3eb715079f0214)