### PR TITLE
Add image block

### DIFF
--- a/src/blocks/ImageBlock.ts
+++ b/src/blocks/ImageBlock.ts
@@ -1,0 +1,32 @@
+import type { Block } from 'payload'
+
+export const ImageBlock: Block = {
+  slug: 'imageBlock',
+  labels: {
+    singular: 'Image Block',
+    plural: 'Image Blocks',
+  },
+  fields: [
+    {
+      name: 'imageUrl',
+      type: 'text',
+      required: true,
+      label: 'Image URL',
+      admin: {
+        description: 'Paste full Cloudinary image URL (https://res.cloudinary.com/...)',
+      },
+    },
+    {
+      name: 'width',
+      type: 'select',
+      required: true,
+      defaultValue: 'full',
+      label: 'Width',
+      options: [
+        { label: 'Full width', value: 'full' },
+        { label: '50%', value: 'half' },
+        { label: 'Original size', value: 'original' },
+      ],
+    },
+  ],
+}

--- a/src/collections/Calendars.ts
+++ b/src/collections/Calendars.ts
@@ -5,6 +5,7 @@ import { GalleryBlock } from '../blocks/GalleryBlock'
 import { InstagramBlock } from '../blocks/InstagramBlock'
 import { CTABlock } from '../blocks/CTABlock'
 import { YouTubeBlock } from '../blocks/YouTubeBlock'
+import { ImageBlock } from '../blocks/ImageBlock'
 
 export const Calendars: CollectionConfig = {
   slug: 'calendars',
@@ -43,7 +44,7 @@ export const Calendars: CollectionConfig = {
         singular: 'Component',
         plural: 'Components',
       },
-      blocks: [RichTextBlock, GalleryBlock, InstagramBlock, CTABlock, YouTubeBlock],
+      blocks: [RichTextBlock, GalleryBlock, InstagramBlock, CTABlock, YouTubeBlock, ImageBlock],
     },
   ],
   timestamps: true,

--- a/src/collections/Events.ts
+++ b/src/collections/Events.ts
@@ -4,6 +4,7 @@ import { RichTextBlock } from '../blocks/RichTextBlock'
 import { GalleryBlock } from '../blocks/GalleryBlock'
 import { InstagramBlock } from '../blocks/InstagramBlock'
 import { CTABlock } from '../blocks/CTABlock'
+import { ImageBlock } from '../blocks/ImageBlock'
 
 export const Events: CollectionConfig = {
   slug: 'events',
@@ -42,7 +43,7 @@ export const Events: CollectionConfig = {
         singular: 'Component',
         plural: 'Components',
       },
-      blocks: [RichTextBlock, GalleryBlock, InstagramBlock, CTABlock],
+      blocks: [RichTextBlock, GalleryBlock, InstagramBlock, CTABlock, ImageBlock],
     },
   ],
   timestamps: true,

--- a/src/collections/Pages.ts
+++ b/src/collections/Pages.ts
@@ -15,6 +15,7 @@ import { CTABlock } from '../blocks/CTABlock'
 import { RichTextBlock } from '../blocks/RichTextBlock'
 import { HeroBlock } from '../blocks/HeroBlock'
 import { EbookRequestBlock } from '../blocks/EbookRequestBlock'
+import { ImageBlock } from '../blocks/ImageBlock'
 
 export const Pages: CollectionConfig = {
   slug: 'pages',
@@ -80,6 +81,7 @@ export const Pages: CollectionConfig = {
         CTABlock,
         RichTextBlock,
         HeroBlock,
+        ImageBlock,
       ],
     },
   ],

--- a/src/components/BlockRenderer.tsx
+++ b/src/components/BlockRenderer.tsx
@@ -13,6 +13,7 @@ import InstagramBlockComponent from './InstagramBlockComponent'
 import CTABlockComponent from './CTABlockComponent'
 import RichTextBlockComponent from './RichTextBlockComponent'
 import HeroBlockComponent from './HeroBlockComponent'
+import ImageBlockComponent from './ImageBlockComponent'
 
 type Props = {
   block: any
@@ -51,6 +52,8 @@ export default function BlockRenderer({ block, locale }: Props) {
       return <RichTextBlockComponent block={block} locale={locale} />
     case 'heroBlock':
       return <HeroBlockComponent block={block} locale={locale} />
+    case 'imageBlock':
+      return <ImageBlockComponent block={block} />
     default:
       return null
   }

--- a/src/components/ImageBlockComponent.tsx
+++ b/src/components/ImageBlockComponent.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils'
+
+type Props = {
+  block: {
+    blockType: 'imageBlock'
+    imageUrl: string
+    width?: 'full' | 'half' | 'original' | null
+  }
+}
+
+const widthClasses: Record<'full' | 'half' | 'original', string> = {
+  full: 'w-full',
+  half: 'w-full md:w-1/2',
+  original: 'w-auto max-w-full',
+}
+
+export default function ImageBlockComponent({ block }: Props) {
+  const width = block.width ?? 'full'
+
+  return (
+    <section className="flex w-full justify-center">
+      <figure className={cn('overflow-hidden', widthClasses[width])}>
+        <img
+          src={block.imageUrl}
+          alt=""
+          className={cn(
+            'h-auto max-w-full rounded-2xl',
+            width === 'full' && 'w-full',
+            width === 'half' && 'w-full',
+          )}
+        />
+      </figure>
+    </section>
+  )
+}

--- a/src/payload-types.ts
+++ b/src/payload-types.ts
@@ -381,6 +381,16 @@ export interface Page {
             blockName?: string | null;
             blockType: 'heroBlock';
           }
+        | {
+            /**
+             * Paste full Cloudinary image URL (https://res.cloudinary.com/...)
+             */
+            imageUrl: string;
+            width: 'full' | 'half' | 'original';
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'imageBlock';
+          }
       )[]
     | null;
   updatedAt: string;
@@ -474,6 +484,16 @@ export interface Event {
             id?: string | null;
             blockName?: string | null;
             blockType: 'ctaBlock';
+          }
+        | {
+            /**
+             * Paste full Cloudinary image URL (https://res.cloudinary.com/...)
+             */
+            imageUrl: string;
+            width: 'full' | 'half' | 'original';
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'imageBlock';
           }
       )[]
     | null;
@@ -577,6 +597,16 @@ export interface Calendar {
             id?: string | null;
             blockName?: string | null;
             blockType: 'youTubeBlock';
+          }
+        | {
+            /**
+             * Paste full Cloudinary image URL (https://res.cloudinary.com/...)
+             */
+            imageUrl: string;
+            width: 'full' | 'half' | 'original';
+            id?: string | null;
+            blockName?: string | null;
+            blockType: 'imageBlock';
           }
       )[]
     | null;
@@ -1002,6 +1032,14 @@ export interface PagesSelect<T extends boolean = true> {
               id?: T;
               blockName?: T;
             };
+        imageBlock?:
+          | T
+          | {
+              imageUrl?: T;
+              width?: T;
+              id?: T;
+              blockName?: T;
+            };
       };
   updatedAt?: T;
   createdAt?: T;
@@ -1055,6 +1093,14 @@ export interface EventsSelect<T extends boolean = true> {
                     openInNewWindow?: T;
                     id?: T;
                   };
+              id?: T;
+              blockName?: T;
+            };
+        imageBlock?:
+          | T
+          | {
+              imageUrl?: T;
+              width?: T;
               id?: T;
               blockName?: T;
             };
@@ -1118,6 +1164,14 @@ export interface CalendarsSelect<T extends boolean = true> {
           | T
           | {
               url?: T;
+              id?: T;
+              blockName?: T;
+            };
+        imageBlock?:
+          | T
+          | {
+              imageUrl?: T;
+              width?: T;
               id?: T;
               blockName?: T;
             };


### PR DESCRIPTION
This pull request introduces a new reusable "Image Block" component to the codebase, enabling editors to add images (with configurable widths) to Pages, Events, and Calendars. The change includes both backend schema updates and frontend rendering logic to support this new block type.

**Image Block Implementation and Integration:**

* Added a new `ImageBlock` definition in `src/blocks/ImageBlock.ts`, allowing editors to specify an image URL (with Cloudinary support) and select the display width (full, half, or original).
* Registered `ImageBlock` as an available block in the `Pages`, `Events`, and `Calendars` collections, so it can be used in their component fields. [[1]](diffhunk://#diff-177b33ac5b4c490af561cd688d75a1954eb1f45127167ebf08fdda7b11e38703R18) [[2]](diffhunk://#diff-177b33ac5b4c490af561cd688d75a1954eb1f45127167ebf08fdda7b11e38703R84) [[3]](diffhunk://#diff-ad80fa814de6091b0bb44b4f605d41a676e30653cac54d484354d2f5b7a3220bR7) [[4]](diffhunk://#diff-ad80fa814de6091b0bb44b4f605d41a676e30653cac54d484354d2f5b7a3220bL45-R46) [[5]](diffhunk://#diff-6c06905f32c5ad85e6f6756b13f8381de5136162227c21d0fcfd6c5cb9db7d28R8) [[6]](diffhunk://#diff-6c06905f32c5ad85e6f6756b13f8381de5136162227c21d0fcfd6c5cb9db7d28L46-R47)

**Frontend Rendering Support:**

* Added a new `ImageBlockComponent` in `src/components/ImageBlockComponent.tsx` to render images responsively based on the selected width.
* Updated the `BlockRenderer` component to support rendering the new `imageBlock` type using the new component. [[1]](diffhunk://#diff-696f1416429cc62ba958de0cd466312831abac4b8d34af53bc20190db04bc966R16) [[2]](diffhunk://#diff-696f1416429cc62ba958de0cd466312831abac4b8d34af53bc20190db04bc966R55-R56)

**Type Definitions and Payload Schema:**

* Updated generated types in `src/payload-types.ts` to include the new `imageBlock` structure for Pages, Events, and Calendars, ensuring type safety throughout the app. [[1]](diffhunk://#diff-5169b7635fb8b2fb179f5f8f4b754aa143d1a627cce5f6a0f9db79639ade7bb0R384-R393) [[2]](diffhunk://#diff-5169b7635fb8b2fb179f5f8f4b754aa143d1a627cce5f6a0f9db79639ade7bb0R488-R497) [[3]](diffhunk://#diff-5169b7635fb8b2fb179f5f8f4b754aa143d1a627cce5f6a0f9db79639ade7bb0R601-R610) [[4]](diffhunk://#diff-5169b7635fb8b2fb179f5f8f4b754aa143d1a627cce5f6a0f9db79639ade7bb0R1035-R1042) [[5]](diffhunk://#diff-5169b7635fb8b2fb179f5f8f4b754aa143d1a627cce5f6a0f9db79639ade7bb0R1099-R1106) [[6]](diffhunk://#diff-5169b7635fb8b2fb179f5f8f4b754aa143d1a627cce5f6a0f9db79639ade7bb0R1170-R1177)