### PR TITLE
fix menu

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,7 @@ const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
 const nextConfig: NextConfig = {
+  allowedDevOrigins: ['127.0.0.1', 'localhost', '10.0.0.221', 'yamagata'],
   experimental: {
     serverActions: {
       allowedOrigins: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,8 +21,7 @@ export default defineConfig({
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://localhost:3000',
+    // baseURL: 'http://127.0.0.1:3100',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -30,12 +29,12 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'], channel: 'chromium' },
+      use: { ...devices['Desktop Chrome'] },
     },
   ],
   webServer: {
-    command: 'pnpm dev',
+    command: 'pnpm exec next dev -p 3100',
     reuseExistingServer: true,
-    url: 'http://localhost:3000',
+    url: 'http://127.0.0.1:3100',
   },
 })

--- a/src/app/(frontend)/[locale]/globals.css
+++ b/src/app/(frontend)/[locale]/globals.css
@@ -179,6 +179,53 @@
   gap: 4rem;
 }
 
+.mobile-menu-overlay {
+  animation: mobile-menu-overlay-in 200ms ease-out;
+}
+
+.mobile-menu-panel {
+  animation: mobile-menu-panel-in 250ms ease-out;
+}
+
+.mobile-menu-overlay[data-state='closed'] {
+  animation: mobile-menu-overlay-out 150ms ease-in forwards;
+}
+
+.mobile-menu-panel[data-state='closed'] {
+  animation: mobile-menu-panel-out 200ms ease-in forwards;
+}
+
+@keyframes mobile-menu-overlay-in {
+  from {
+    opacity: 0;
+  }
+}
+
+@keyframes mobile-menu-overlay-out {
+  to {
+    opacity: 0;
+  }
+}
+
+@keyframes mobile-menu-panel-in {
+  from {
+    transform: translateX(100%);
+  }
+}
+
+@keyframes mobile-menu-panel-out {
+  to {
+    transform: translateX(100%);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mobile-menu-overlay,
+  .mobile-menu-panel {
+    animation-duration: 0.01ms;
+  }
+}
+
 .rich-text-content {
   color: rgb(15 23 42);
   max-width: none;

--- a/src/app/(frontend)/[locale]/layout.tsx
+++ b/src/app/(frontend)/[locale]/layout.tsx
@@ -2,13 +2,15 @@ import React from 'react'
 import { notFound } from 'next/navigation'
 import type { Metadata } from 'next'
 import { Mulish } from 'next/font/google'
-import SiteHeader from '@/components/SiteHeader'
+import { getPayload } from 'payload'
+import SiteHeader, { type NavigationPage } from '@/components/SiteHeader'
 import { SlugProvider } from '@/components/SlugProvider'
 import SiteFooter from '@/components/Footer'
 import { LOCALE_CODES } from '@/constants/locales'
 import { isSupportedLocale } from '@/lib/locales'
 import { buildLocaleMetadata } from '@/lib/metadata'
 import { cn } from '@/lib/utils'
+import config from '@/payload.config'
 import './globals.css'
 
 const fontSans = Mulish({
@@ -40,6 +42,31 @@ export default async function RootLayout(props: {
     notFound()
   }
 
+  const payloadConfig = await config
+  const payload = await getPayload({ config: payloadConfig })
+  const { docs } = await payload.find({
+    collection: 'pages',
+    locale,
+    where: {
+      and: [{ showInNavbar: { equals: true } }, { status: { equals: 'published' } }],
+    },
+    limit: 100,
+    sort: 'title',
+    select: {
+      title: true,
+      slug: true,
+    },
+  })
+  const navigationPages: NavigationPage[] = docs
+    .filter((page): page is typeof page & { slug: string; title: string } => {
+      return typeof page.slug === 'string' && typeof page.title === 'string'
+    })
+    .map((page) => ({
+      id: String(page.id),
+      slug: page.slug,
+      title: page.title,
+    }))
+
   return (
     <html lang={locale}>
       <body
@@ -48,9 +75,7 @@ export default async function RootLayout(props: {
         <SlugProvider>
           <div className="px-4 md:px-6 lg:px-8">
             <div className="mx-auto flex min-h-screen max-w-7xl flex-col py-4 md:py-6 lg:py-8">
-              <React.Suspense fallback={null}>
-                <SiteHeader locale={locale} />
-              </React.Suspense>
+              <SiteHeader locale={locale} pages={navigationPages} />
               <main className="flex-1">{children}</main>
               <SiteFooter locale={locale} />
             </div>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -2,10 +2,12 @@
 
 import Link from 'next/link'
 import { usePathname, useSearchParams } from 'next/navigation'
+import * as Dialog from '@radix-ui/react-dialog'
+import { X } from 'lucide-react'
 import React from 'react'
 import { BrazilFlagIcon, BrincaLogo, CanadaFlagIcon, MenuIcon } from '@/components/brinca/BrandIcons'
 import { useSlug } from '@/components/SlugProvider'
-import { Dialog, DialogClose, DialogContent, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
+import type { LocaleCode } from '@/constants/locales'
 
 const LOCALES = ['en', 'pt-BR'] as const
 const FLAG_BY_LOCALE = {
@@ -13,40 +15,25 @@ const FLAG_BY_LOCALE = {
   'pt-BR': BrazilFlagIcon,
 } as const
 
-export default function SiteHeader({ locale }: { locale: string }) {
+export type NavigationPage = {
+  id: string
+  slug: string
+  title: string
+}
+
+type LanguageSwitcherProps = {
+  locale: LocaleCode
+  onNavigate?: () => void
+  tabIndex?: number
+}
+
+function LanguageSwitcher({ locale, onNavigate, tabIndex }: LanguageSwitcherProps) {
   const pathname = usePathname() || `/${locale}`
   const searchParams = useSearchParams()
   const search = searchParams && searchParams.toString() ? `?${searchParams.toString()}` : ''
-  const { slugMap: rawSlugMap } = useSlug()
-  const [isMounted, setIsMounted] = React.useState(false)
-  const [pages, setPages] = React.useState<any[]>([])
-
-  React.useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  const slugMap = isMounted ? rawSlugMap : {}
+  const { slugMap } = useSlug()
   const segments = pathname.split('/').filter(Boolean)
   const hasLocale = segments.length > 0 && LOCALES.includes(segments[0] as (typeof LOCALES)[number])
-
-  React.useEffect(() => {
-    let mounted = true
-
-    ;(async () => {
-      try {
-        const res = await fetch(`/api/public/pages?locale=${encodeURIComponent(locale)}`)
-        if (!res.ok) return
-        const json = await res.json()
-        if (mounted) setPages(json.pages || [])
-      } catch {
-        // Ignore nav fetch failures and fall back to static slugs.
-      }
-    })()
-
-    return () => {
-      mounted = false
-    }
-  }, [locale])
 
   const getLocaleHref = (targetLocale: (typeof LOCALES)[number]) => {
     let href = `/${targetLocale}${pathname}`
@@ -69,6 +56,33 @@ export default function SiteHeader({ locale }: { locale: string }) {
     return href
   }
 
+  return LOCALES.map((targetLocale) => {
+    const Flag = FLAG_BY_LOCALE[targetLocale]
+
+    return (
+      <Link
+        key={targetLocale}
+        href={getLocaleHref(targetLocale)}
+        title={targetLocale === 'en' ? 'English' : 'Português'}
+        className="flex text-2xl transition-opacity duration-[0.25s] ease-out hover:opacity-50"
+        onClick={onNavigate}
+        tabIndex={tabIndex}
+      >
+        <Flag />
+      </Link>
+    )
+  })
+}
+
+export default function SiteHeader({
+  locale,
+  pages,
+}: {
+  locale: LocaleCode
+  pages: NavigationPage[]
+}) {
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = React.useState(false)
+
   return (
     <header>
       <nav className="flex gap-8">
@@ -80,98 +94,83 @@ export default function SiteHeader({ locale }: { locale: string }) {
 
         <div className="ml-auto flex items-center">
           <div className="hidden items-center gap-8 xl:flex">
-            {pages.map((page: any) => {
-              const slug = typeof page.slug === 'string' ? page.slug : page.slug?.[locale]
-              if (!slug) return null
-
-              return (
-                <Link
-                  key={page.id}
-                  href={`/${locale}/${slug}`}
-                  className="group relative inline whitespace-nowrap font-normal"
-                >
-                  <span className="transition-colors duration-200 ease-in-out group-hover:text-[#16a34a]">
-                    {page.title?.[locale] ?? page.title ?? 'Page'}
-                  </span>
-                  <span className="absolute left-0 top-full mt-1 block h-[3px] w-0 rounded-full bg-[#16a34a] transition-all duration-200 ease-in-out group-hover:w-full" />
-                </Link>
-              )
-            })}
+            {pages.map((page) => (
+              <Link
+                key={page.id}
+                href={`/${locale}/${page.slug}`}
+                className="group relative inline whitespace-nowrap font-normal"
+              >
+                <span className="transition-colors duration-200 ease-in-out group-hover:text-[#16a34a]">
+                  {page.title}
+                </span>
+                <span className="absolute left-0 top-full mt-1 block h-[3px] w-0 rounded-full bg-[#16a34a] transition-all duration-200 ease-in-out group-hover:w-full" />
+              </Link>
+            ))}
 
             <div className="rotate-90 transform xl:rotate-0">|</div>
 
             <div className="flex items-center gap-4" aria-label="Language switcher">
-              {LOCALES.map((targetLocale) => {
-                const Flag = FLAG_BY_LOCALE[targetLocale]
-
-                return (
-                  <Link
-                    key={targetLocale}
-                    href={getLocaleHref(targetLocale)}
-                    title={targetLocale === 'en' ? 'English' : 'Português'}
-                    className="flex text-2xl transition-opacity duration-[0.25s] ease-out hover:opacity-50"
-                  >
-                    <Flag />
-                  </Link>
-                )
-              })}
+              <React.Suspense fallback={null}>
+                <LanguageSwitcher locale={locale} />
+              </React.Suspense>
             </div>
           </div>
 
-          <Dialog>
-            <DialogTrigger asChild>
-              <button className="flex p-2 xl:hidden" aria-label="Open navigation menu">
-                <MenuIcon />
-              </button>
-            </DialogTrigger>
+          <div className="xl:hidden">
+            <Dialog.Root open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
+              <Dialog.Trigger asChild>
+                <button
+                  type="button"
+                  className="flex cursor-pointer p-2"
+                  aria-label="Open navigation menu"
+                >
+                  <MenuIcon />
+                </button>
+              </Dialog.Trigger>
 
-            <DialogContent
-              showCloseButton={false}
-              className="left-auto right-0 top-0 h-screen w-screen max-w-none translate-x-0 translate-y-0 gap-8 border-0 bg-white px-8 py-16 shadow-none duration-200 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-right-full md:w-1/2 md:shadow-2xl"
-            >
-              <DialogTitle className="sr-only">Navigation menu</DialogTitle>
-              <div className="absolute right-6 top-8 z-50">
-                <DialogClose asChild>
-                  <button className="flex p-2" aria-label="Close navigation menu">
-                    <MenuIcon className="rotate-90" />
-                  </button>
-                </DialogClose>
-              </div>
+              <Dialog.Portal>
+                <Dialog.Overlay className="mobile-menu-overlay fixed inset-0 z-40 bg-black/80" />
+                <Dialog.Content
+                  id="mobile-navigation-menu"
+                  aria-describedby={undefined}
+                  className="mobile-menu-panel fixed right-0 top-0 z-50 flex h-dvh w-screen flex-col gap-8 overflow-y-auto bg-white px-8 py-16 shadow-none focus:outline-none md:w-1/2 md:shadow-2xl"
+                >
+                  <Dialog.Title className="sr-only">Navigation menu</Dialog.Title>
+                  <Dialog.Close asChild>
+                    <button
+                      type="button"
+                      className="absolute right-6 top-8 z-[60] flex cursor-pointer p-2"
+                      aria-label="Close navigation menu"
+                    >
+                      <X className="h-5 w-5 text-[#16a34a]" aria-hidden="true" />
+                    </button>
+                  </Dialog.Close>
 
-              <div className="flex flex-col gap-8 overflow-y-auto">
-                {pages.map((page: any) => {
-                  const slug = typeof page.slug === 'string' ? page.slug : page.slug?.[locale]
-                  if (!slug) return null
-
-                  return (
-                    <DialogClose asChild key={page.id}>
-                      <Link href={`/${locale}/${slug}`} className="inline text-[20px] leading-normal font-normal">
-                        {page.title?.[locale] ?? page.title ?? 'Page'}
-                      </Link>
-                    </DialogClose>
-                  )
-                })}
-
-                <div className="mx-auto flex items-center gap-4">
-                  {LOCALES.map((targetLocale) => {
-                    const Flag = FLAG_BY_LOCALE[targetLocale]
-
-                    return (
-                      <DialogClose asChild key={targetLocale}>
+                  <div className="flex flex-col gap-8 overflow-y-auto">
+                    {pages.map((page) => (
+                      <Dialog.Close asChild key={page.id}>
                         <Link
-                          href={getLocaleHref(targetLocale)}
-                          title={targetLocale === 'en' ? 'English' : 'Português'}
-                          className="flex text-2xl transition-opacity duration-[0.25s] ease-out hover:opacity-50"
+                          href={`/${locale}/${page.slug}`}
+                          className="inline text-[20px] leading-normal font-normal"
                         >
-                          <Flag />
+                          {page.title}
                         </Link>
-                      </DialogClose>
-                    )
-                  })}
-                </div>
-              </div>
-            </DialogContent>
-          </Dialog>
+                      </Dialog.Close>
+                    ))}
+
+                    <div className="mx-auto flex items-center gap-4">
+                      <React.Suspense fallback={null}>
+                        <LanguageSwitcher
+                          locale={locale}
+                          onNavigate={() => setIsMobileMenuOpen(false)}
+                        />
+                      </React.Suspense>
+                    </div>
+                  </div>
+                </Dialog.Content>
+              </Dialog.Portal>
+            </Dialog.Root>
+          </div>
         </div>
       </nav>
     </header>

--- a/src/constants/locales.ts
+++ b/src/constants/locales.ts
@@ -1,7 +1,7 @@
 const LOCALES = [
   { code: 'en', label: 'English' },
   { code: 'pt-BR', label: 'Português' },
-]
+] as const
 
 export const LOCALE_CODES = LOCALES.map((locale) => locale.code)
 

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -9,12 +9,47 @@ test.describe('Frontend', () => {
   })
 
   test('can go on homepage', async ({ page }) => {
-    await page.goto('http://localhost:3000')
+    await page.goto('/')
 
     await expect(page).toHaveTitle(/Payload Blank Template/)
 
     const heading = page.locator('h1').first()
 
     await expect(heading).toHaveText('Welcome to your new project.')
+  })
+
+  test('renders the home page navigation without client-side JavaScript', async ({ browser }) => {
+    const context = await browser.newContext({ javaScriptEnabled: false })
+    const page = await context.newPage()
+
+    await page.goto('/en')
+
+    await expect(page.locator('header')).toBeVisible()
+    await expect(page.locator('header a[href="/en/about-us"]')).toHaveText('About Us')
+    await expect(page.locator('header a[href="/en/contact-us"]')).toHaveText('Contact Us')
+
+    await context.close()
+  })
+
+  test('opens and closes the mobile menu on the home page', async ({ browser }) => {
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+    })
+    const page = await context.newPage()
+
+    await page.goto('/en')
+
+    await expect(page.getByRole('dialog')).toBeHidden()
+    await page.getByRole('button', { name: 'Open navigation menu' }).click()
+    await expect(page.getByRole('dialog')).toBeVisible()
+    await expect(page.getByRole('dialog').getByRole('link', { name: 'About Us' })).toBeVisible()
+
+    await page.getByRole('dialog').getByRole('button', { name: 'Close navigation menu' }).click()
+    await expect(page.getByRole('dialog')).toBeHidden()
+
+    await page.reload()
+    await expect(page.getByRole('dialog')).toBeHidden()
+
+    await context.close()
   })
 })


### PR DESCRIPTION
This pull request refactors the navigation system to fetch navigation pages server-side, improves the mobile menu accessibility and animation, and updates Playwright and e2e tests for improved reliability and coverage. The most important changes are summarized below:

**Navigation Refactor and Accessibility Improvements:**

* Navigation pages are now fetched server-side in `RootLayout`, ensuring navigation works without client-side JavaScript and improving SEO. The `SiteHeader` component now receives navigation pages as a prop instead of fetching them client-side. ([src/app/(frontend)/[locale]/layout.tsxL5-R13](diffhunk://#diff-50fddd4db8e93c18c55bf6807495c80ae359c6550c1b2ff4bffffd053997106eL5-R13), [src/app/(frontend)/[locale]/layout.tsxR45-R69](diffhunk://#diff-50fddd4db8e93c18c55bf6807495c80ae359c6550c1b2ff4bffffd053997106eR45-R69), [src/app/(frontend)/[locale]/layout.tsxL51-R78](diffhunk://#diff-50fddd4db8e93c18c55bf6807495c80ae359c6550c1b2ff4bffffd053997106eL51-R78), [[1]](diffhunk://#diff-d3654473a7586329ad6ed8dc646e3a5ffedac5fe711c33d25cf7144cee325255R5-L50) [[2]](diffhunk://#diff-d3654473a7586329ad6ed8dc646e3a5ffedac5fe711c33d25cf7144cee325255R59-R85) [[3]](diffhunk://#diff-d3654473a7586329ad6ed8dc646e3a5ffedac5fe711c33d25cf7144cee325255L83-L174)
* The mobile menu is fully refactored to use Radix UI Dialog primitives directly, with improved accessibility, keyboard support, and close button. New animations are added for opening/closing the menu, and reduced motion is respected. [[1]](diffhunk://#diff-d3654473a7586329ad6ed8dc646e3a5ffedac5fe711c33d25cf7144cee325255R5-L50) [[2]](diffhunk://#diff-d3654473a7586329ad6ed8dc646e3a5ffedac5fe711c33d25cf7144cee325255R59-R85) [[3]](diffhunk://#diff-d3654473a7586329ad6ed8dc646e3a5ffedac5fe711c33d25cf7144cee325255L83-L174) [src/app/(frontend)/[locale]/globals.cssR182-R228](diffhunk://#diff-663a633101b644541adb01695fbe6a8dcbe2275a31294b1cf25d7aea955ebc51R182-R228))

**Testing and Configuration Updates:**

* Playwright configuration is updated to use `127.0.0.1:3100` for local development, improving test reliability.
* End-to-end tests are added to verify navigation renders correctly without client-side JavaScript and that the mobile menu opens/closes as expected.

**Minor Improvements:**

* The `LOCALES` constant is now a `const` assertion, improving type safety.
* Allowed development origins are updated in `next.config.ts` for improved local testing.