### PR TITLE
update cloudnary folder

### DIFF
--- a/src/app/(payload)/admin/importMap.js
+++ b/src/app/(payload)/admin/importMap.js
@@ -1,4 +1,5 @@
 import { SlugField as SlugField_2b8867833a34864a02ddf429b0728a40 } from '@payloadcms/next/client'
+import { CloudinaryFolderField as CloudinaryFolderField_780b0f72dcd82f013e6d7b01e9f4fab5 } from '@/components/CloudinaryFolderField'
 import { RscEntryLexicalCell as RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { RscEntryLexicalField as RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
 import { LexicalDiffComponent as LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e } from '@payloadcms/richtext-lexical/rsc'
@@ -26,6 +27,7 @@ import { CollectionCards as CollectionCards_f9c02e79a4aed9a3924487c0cd4cafb1 } f
 
 export const importMap = {
   "@payloadcms/next/client#SlugField": SlugField_2b8867833a34864a02ddf429b0728a40,
+  "@/components/CloudinaryFolderField#CloudinaryFolderField": CloudinaryFolderField_780b0f72dcd82f013e6d7b01e9f4fab5,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalCell": RscEntryLexicalCell_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#RscEntryLexicalField": RscEntryLexicalField_44fe37237e0ebf4470c9990d8cb7b07e,
   "@payloadcms/richtext-lexical/rsc#LexicalDiffComponent": LexicalDiffComponent_44fe37237e0ebf4470c9990d8cb7b07e,

--- a/src/blocks/GalleryBlock.ts
+++ b/src/blocks/GalleryBlock.ts
@@ -14,6 +14,9 @@ export const GalleryBlock: Block = {
       label: 'Cloudinary Folder Path',
       admin: {
         description: 'Cloudinary folder path to load images from (e.g. brinca/events/2026)',
+        components: {
+          Field: '@/components/CloudinaryFolderField#CloudinaryFolderField',
+        },
       },
     },
     {

--- a/src/components/CloudinaryFolderField.scss
+++ b/src/components/CloudinaryFolderField.scss
@@ -1,0 +1,13 @@
+.cloudinary-folder-field {
+  &__error {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    margin-top: calc(var(--base) / 2);
+
+    .btn {
+      flex-shrink: 0;
+      margin: 0 0 0 var(--base);
+    }
+  }
+}

--- a/src/components/CloudinaryFolderField.tsx
+++ b/src/components/CloudinaryFolderField.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import {
+  Banner,
+  Button,
+  FieldDescription,
+  FieldError,
+  FieldLabel,
+  ReactSelect,
+  fieldBaseClass,
+  useField,
+} from '@payloadcms/ui'
+import type { ReactSelectOption } from '@payloadcms/ui'
+import type { TextFieldClientComponent, Validate } from 'payload'
+import React, { useEffect, useMemo, useState } from 'react'
+
+import './CloudinaryFolderField.scss'
+
+type CloudinaryFoldersResponse = {
+  folders?: unknown
+}
+
+function toOption(path: string): ReactSelectOption {
+  return {
+    label: path,
+    value: path,
+  }
+}
+
+export const CloudinaryFolderField: TextFieldClientComponent = ({
+  field,
+  path: pathFromProps,
+  readOnly,
+  validate,
+}) => {
+  const { admin, label, localized, required } = field
+  const { disabled, path, setValue, showError, value } = useField<string>({
+    potentiallyStalePath: pathFromProps,
+    validate: validate as Validate | undefined,
+  })
+  const [folders, setFolders] = useState<string[]>([])
+  const [error, setError] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [requestKey, setRequestKey] = useState(0)
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    async function loadFolders() {
+      setError(false)
+      setLoading(true)
+
+      try {
+        const response = await fetch('/api/cloudinary-folders', {
+          signal: controller.signal,
+        })
+
+        if (!response.ok) {
+          throw new Error('Unable to load Cloudinary folders.')
+        }
+
+        const data = (await response.json()) as CloudinaryFoldersResponse
+        if (
+          !Array.isArray(data.folders) ||
+          !data.folders.every((folder) => typeof folder === 'string')
+        ) {
+          throw new Error('Cloudinary returned an invalid folder list.')
+        }
+
+        setFolders(data.folders)
+      } catch (loadError) {
+        if (loadError instanceof DOMException && loadError.name === 'AbortError') {
+          return
+        }
+
+        setError(true)
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void loadFolders()
+
+    return () => controller.abort()
+  }, [requestKey])
+
+  const options = useMemo(() => {
+    const availableFolders = value && !folders.includes(value) ? [value, ...folders] : folders
+    return availableFolders.map(toOption)
+  }, [folders, value])
+
+  const selectedOption = value ? toOption(value) : undefined
+  const isDisabled = Boolean(readOnly || disabled)
+
+  return (
+    <div
+      className={[
+        fieldBaseClass,
+        'cloudinary-folder-field',
+        showError && 'error',
+        isDisabled && 'read-only',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <FieldLabel label={label} localized={localized} path={path} required={required} />
+      <div className={`${fieldBaseClass}__wrap`}>
+        <FieldError path={path} showError={showError} />
+        <ReactSelect
+          className={`field-${path.replace(/\./g, '__')}`}
+          disabled={isDisabled}
+          isClearable={!required}
+          isCreatable
+          isLoading={loading}
+          isSearchable
+          noOptionsMessage={() =>
+            loading
+              ? 'Loading Cloudinary folders…'
+              : 'No Cloudinary folders found. Type a folder path to add it manually.'
+          }
+          onChange={(option) => {
+            if (Array.isArray(option)) {
+              return
+            }
+
+            setValue(typeof option?.value === 'string' ? option.value : null)
+          }}
+          options={options}
+          placeholder="Search or enter a Cloudinary folder path"
+          showError={showError}
+          value={selectedOption}
+        />
+        {error && (
+          <Banner className="cloudinary-folder-field__error" type="error">
+            <span>Cloudinary folders could not be loaded. You can enter a path manually.</span>
+            <Button
+              buttonStyle="secondary"
+              onClick={() => setRequestKey((current) => current + 1)}
+              size="small"
+              type="button"
+            >
+              Retry
+            </Button>
+          </Banner>
+        )}
+        <FieldDescription description={admin?.description} path={path} />
+      </div>
+    </div>
+  )
+}

--- a/src/endpoints/cloudinaryFolders.ts
+++ b/src/endpoints/cloudinaryFolders.ts
@@ -1,0 +1,24 @@
+import type { Endpoint } from 'payload'
+import { getCloudinaryFolderPaths } from '@/lib/cloudinary'
+
+export const cloudinaryFoldersEndpoint: Endpoint = {
+  path: '/cloudinary-folders',
+  method: 'get',
+  handler: async (req) => {
+    if (!req.user) {
+      return Response.json({ error: 'Unauthorized.' }, { status: 401 })
+    }
+
+    try {
+      const folders = await getCloudinaryFolderPaths()
+      return Response.json({ folders })
+    } catch (error) {
+      req.payload.logger.error({
+        err: error,
+        msg: 'Failed to load Cloudinary folders.',
+      })
+
+      return Response.json({ error: 'Unable to load Cloudinary folders.' }, { status: 502 })
+    }
+  },
+}

--- a/src/lib/cloudinary.ts
+++ b/src/lib/cloudinary.ts
@@ -11,6 +11,15 @@ type CloudinaryResourcesResponse = {
   resources?: CloudinaryResource[]
 }
 
+type CloudinaryFolder = {
+  path?: string
+}
+
+type CloudinaryFoldersResponse = {
+  folders?: CloudinaryFolder[]
+  next_cursor?: string
+}
+
 export type CloudinaryGalleryImage = {
   alt: string
   id: string
@@ -40,6 +49,54 @@ function getImageAlt(resource: CloudinaryResource) {
 
   const name = resource.public_id.split('/').pop() ?? resource.public_id
   return name.replace(/[-_]+/g, ' ')
+}
+
+export async function getCloudinaryFolderPaths(): Promise<string[]> {
+  const { apiKey, apiSecret, cloudName } = getCloudinaryCredentials()
+  const authorization = `Basic ${Buffer.from(`${apiKey}:${apiSecret}`).toString('base64')}`
+  const folderPaths = new Set<string>()
+  let nextCursor: string | undefined
+
+  do {
+    const apiUrl = new URL(
+      `https://api.cloudinary.com/v1_1/${encodeURIComponent(cloudName)}/folders/search`,
+    )
+    apiUrl.searchParams.set('max_results', '500')
+
+    if (nextCursor) {
+      apiUrl.searchParams.set('next_cursor', nextCursor)
+    }
+
+    const response = await fetch(apiUrl.toString(), {
+      headers: {
+        Authorization: authorization,
+      },
+      cache: 'no-store',
+    })
+
+    if (!response.ok) {
+      const detail = await response.text()
+      throw new Error(`Failed to load Cloudinary folders: ${detail}`)
+    }
+
+    const data = (await response.json()) as CloudinaryFoldersResponse
+    const folders = Array.isArray(data.folders) ? data.folders : []
+
+    for (const folder of folders) {
+      if (typeof folder.path !== 'string') {
+        continue
+      }
+
+      const normalizedPath = normalizeFolderPath(folder.path)
+      if (normalizedPath) {
+        folderPaths.add(normalizedPath)
+      }
+    }
+
+    nextCursor = data.next_cursor
+  } while (nextCursor)
+
+  return [...folderPaths].sort((left, right) => left.localeCompare(right))
 }
 
 export async function getCloudinaryFolderImages(

--- a/src/payload.config.ts
+++ b/src/payload.config.ts
@@ -17,6 +17,7 @@ import { Mentors } from './collections/Mentors'
 import { MentorRequests } from './collections/MentorRequests'
 import { Sponsors } from './collections/Sponsors'
 import { EbookRequests } from './collections/EbookRequests'
+import { cloudinaryFoldersEndpoint } from './endpoints/cloudinaryFolders'
 
 const filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(filename)
@@ -36,7 +37,20 @@ export default buildConfig({
     defaultLocale: 'en',
     fallback: true,
   },
-  collections: [Users, Media, Pages, Events, Calendars, PartnerCategories, Partners, Mentors, MentorRequests, Sponsors, EbookRequests],
+  collections: [
+    Users,
+    Media,
+    Pages,
+    Events,
+    Calendars,
+    PartnerCategories,
+    Partners,
+    Mentors,
+    MentorRequests,
+    Sponsors,
+    EbookRequests,
+  ],
+  endpoints: [cloudinaryFoldersEndpoint],
   editor: lexicalEditor(),
   email: resendAdapter({
     defaultFromAddress: process.env.RESEND_FROM_ADDRESS || '',

--- a/tests/int/cloudinary-folder-field.int.spec.tsx
+++ b/tests/int/cloudinary-folder-field.int.spec.tsx
@@ -1,0 +1,143 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ComponentType } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const useField = vi.hoisted(() => vi.fn())
+
+vi.mock('@payloadcms/ui', async () => {
+  const React = await import('react')
+
+  return {
+    Banner: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', { role: 'alert' }, children),
+    Button: ({
+      children,
+      onClick,
+    }: {
+      children: React.ReactNode
+      onClick?: React.MouseEventHandler<HTMLButtonElement>
+    }) => React.createElement('button', { onClick }, children),
+    FieldDescription: () => null,
+    FieldError: () => null,
+    FieldLabel: ({ label }: { label?: React.ReactNode }) =>
+      React.createElement('label', null, label),
+    ReactSelect: ({
+      isLoading,
+      onChange,
+      options,
+      value,
+    }: {
+      isLoading?: boolean
+      onChange: (option: { label: string; value: string }) => void
+      options: Array<{ label: string; value: string }>
+      value?: { value?: string }
+    }) =>
+      React.createElement(
+        'div',
+        {
+          'data-loading': String(Boolean(isLoading)),
+          'data-options': options.map((option) => option.value).join(','),
+          'data-testid': 'folder-selector',
+          'data-value': value?.value ?? '',
+        },
+        React.createElement(
+          'button',
+          {
+            onClick: () => onChange({ label: 'root/nested', value: 'root/nested' }),
+          },
+          'Select nested folder',
+        ),
+        React.createElement(
+          'button',
+          {
+            onClick: () => onChange({ label: 'manual/path', value: 'manual/path' }),
+          },
+          'Enter manual folder',
+        ),
+      ),
+    fieldBaseClass: 'field-type',
+    useField,
+  }
+})
+
+import { CloudinaryFolderField } from '@/components/CloudinaryFolderField'
+
+const FolderField = CloudinaryFolderField as ComponentType<Record<string, unknown>>
+
+describe('Cloudinary folder field', () => {
+  const setValue = vi.fn()
+
+  beforeEach(() => {
+    setValue.mockReset()
+    useField.mockReset()
+    useField.mockReturnValue({
+      disabled: false,
+      path: 'components.0.cloudinaryFolder',
+      setValue,
+      showError: false,
+      value: 'legacy/unlisted',
+    })
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            folders: ['root', 'root/nested'],
+          }),
+        ),
+      ),
+    )
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it('restores an unlisted saved value and updates from Cloudinary results', async () => {
+    render(
+      <FolderField
+        field={{
+          admin: { description: 'Choose a folder' },
+          label: 'Cloudinary Folder Path',
+          name: 'cloudinaryFolder',
+          required: true,
+          type: 'text',
+        }}
+        path="components.0.cloudinaryFolder"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('folder-selector').getAttribute('data-loading')).toBe('false')
+    })
+
+    const selector = screen.getByTestId('folder-selector')
+    expect(selector.getAttribute('data-value')).toBe('legacy/unlisted')
+    expect(selector.getAttribute('data-options')).toBe('legacy/unlisted,root,root/nested')
+
+    fireEvent.click(screen.getByRole('button', { name: 'Select nested folder' }))
+    expect(setValue).toHaveBeenCalledWith('root/nested')
+  })
+
+  it('allows a manual fallback path', async () => {
+    render(
+      <FolderField
+        field={{
+          label: 'Cloudinary Folder Path',
+          name: 'cloudinaryFolder',
+          required: true,
+          type: 'text',
+        }}
+        path="components.0.cloudinaryFolder"
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('folder-selector').getAttribute('data-loading')).toBe('false')
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Enter manual folder' }))
+    expect(setValue).toHaveBeenCalledWith('manual/path')
+  })
+})

--- a/tests/int/cloudinary-folders-endpoint.int.spec.ts
+++ b/tests/int/cloudinary-folders-endpoint.int.spec.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getCloudinaryFolderPaths = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/cloudinary', () => ({
+  getCloudinaryFolderPaths,
+}))
+
+import { cloudinaryFoldersEndpoint } from '@/endpoints/cloudinaryFolders'
+
+describe('Cloudinary folders endpoint', () => {
+  beforeEach(() => {
+    getCloudinaryFolderPaths.mockReset()
+  })
+
+  it('rejects anonymous requests without calling Cloudinary', async () => {
+    const response = await cloudinaryFoldersEndpoint.handler({
+      user: null,
+    } as never)
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({ error: 'Unauthorized.' })
+    expect(getCloudinaryFolderPaths).not.toHaveBeenCalled()
+  })
+
+  it('returns folders to authenticated Payload users', async () => {
+    getCloudinaryFolderPaths.mockResolvedValue(['root', 'root/nested'])
+
+    const response = await cloudinaryFoldersEndpoint.handler({
+      user: { id: 'user-id' },
+    } as never)
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      folders: ['root', 'root/nested'],
+    })
+  })
+
+  it('logs upstream failures and returns a sanitized error', async () => {
+    const loggerError = vi.fn()
+    getCloudinaryFolderPaths.mockRejectedValue(new Error('secret upstream detail'))
+
+    const response = await cloudinaryFoldersEndpoint.handler({
+      payload: {
+        logger: {
+          error: loggerError,
+        },
+      },
+      user: { id: 'user-id' },
+    } as never)
+
+    expect(response.status).toBe(502)
+    const body = await response.json()
+    expect(body).toEqual({
+      error: 'Unable to load Cloudinary folders.',
+    })
+    expect(loggerError).toHaveBeenCalledOnce()
+    expect(JSON.stringify(body)).not.toContain('secret upstream detail')
+  })
+})

--- a/tests/int/cloudinary.int.spec.ts
+++ b/tests/int/cloudinary.int.spec.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getCloudinaryFolderPaths } from '@/lib/cloudinary'
+
+const originalCloudName = process.env.CLOUDINARY_CLOUD_NAME
+const originalApiKey = process.env.CLOUDINARY_API_KEY
+const originalApiSecret = process.env.CLOUDINARY_API_SECRET
+
+describe('Cloudinary folders', () => {
+  beforeEach(() => {
+    process.env.CLOUDINARY_CLOUD_NAME = 'test-cloud'
+    process.env.CLOUDINARY_API_KEY = 'test-key'
+    process.env.CLOUDINARY_API_SECRET = 'test-secret'
+  })
+
+  afterEach(() => {
+    process.env.CLOUDINARY_CLOUD_NAME = originalCloudName
+    process.env.CLOUDINARY_API_KEY = originalApiKey
+    process.env.CLOUDINARY_API_SECRET = originalApiSecret
+    vi.unstubAllGlobals()
+  })
+
+  it('loads, normalizes, deduplicates, sorts, and paginates folder paths', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            folders: [{ path: 'root/nested' }, { path: '/root/' }, { path: null }],
+            next_cursor: 'next-page',
+          }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            folders: [{ path: 'another' }, { path: 'root/nested' }],
+          }),
+        ),
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getCloudinaryFolderPaths()).resolves.toEqual(['another', 'root', 'root/nested'])
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    const [firstURL, firstOptions] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(firstURL).toBe(
+      'https://api.cloudinary.com/v1_1/test-cloud/folders/search?max_results=500',
+    )
+    expect(firstOptions).toMatchObject({
+      cache: 'no-store',
+      headers: {
+        Authorization: `Basic ${Buffer.from('test-key:test-secret').toString('base64')}`,
+      },
+    })
+
+    const [secondURL] = fetchMock.mock.calls[1] as [string]
+    expect(new URL(secondURL).searchParams.get('next_cursor')).toBe('next-page')
+  })
+
+  it('throws when Cloudinary returns an error', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('rate limited', { status: 429 })))
+
+    await expect(getCloudinaryFolderPaths()).rejects.toThrow(
+      'Failed to load Cloudinary folders: rate limited',
+    )
+  })
+
+  it('throws before requesting Cloudinary when credentials are missing', async () => {
+    delete process.env.CLOUDINARY_API_SECRET
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getCloudinaryFolderPaths()).rejects.toThrow(
+      'Cloudinary environment variables are not configured.',
+    )
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -7,6 +7,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
-    include: ['tests/int/**/*.int.spec.ts'],
+    include: ['tests/int/**/*.int.spec.{ts,tsx}'],
   },
 })


### PR DESCRIPTION
This pull request introduces a new Cloudinary folder picker field for the Payload admin UI, allowing users to select a Cloudinary folder from a dynamically loaded list, with fallback support for manual entry. It includes a new API endpoint for securely fetching folder lists from Cloudinary, robust error handling, and comprehensive integration tests for both the UI component and backend. The implementation ensures only authenticated users can query Cloudinary, and the folder picker gracefully handles errors and paginated results.

**Cloudinary Folder Picker Feature:**

* Added a new `CloudinaryFolderField` React component (`src/components/CloudinaryFolderField.tsx`) with a custom UI for selecting or entering Cloudinary folder paths, including error handling and a retry mechanism. (`[src/components/CloudinaryFolderField.tsxR1-R152](diffhunk://#diff-1c9cd5fbe82fbb663ab0a22cf612119a7059032797a389029028f4988e18a5bdR1-R152)`)
* Integrated the new field into the Payload admin UI by updating the import map and using the component in the `GalleryBlock` configuration. (`[[1]](diffhunk://#diff-d8fcf2008238d20b6b3128406e49030f949593ccf484c4f4b79a9fb86579195fR2)`, `[[2]](diffhunk://#diff-d8fcf2008238d20b6b3128406e49030f949593ccf484c4f4b79a9fb86579195fR30)`, `[[3]](diffhunk://#diff-64298639a34fd81921e575cdf2dd26b1df2f3704f9ff5ed325e07efd604ffe10R17-R19)`)
* Added styles for the new field in `CloudinaryFolderField.scss`. (`[src/components/CloudinaryFolderField.scssR1-R13](diffhunk://#diff-dff161173cce85007186ee7f4d08ff1441c47a4f9e1e372789d70e68ec756587R1-R13)`)

**Backend API & Cloudinary Integration:**

* Implemented a new authenticated endpoint `/cloudinary-folders` that returns available Cloudinary folder paths, with error logging and proper response codes. (`[src/endpoints/cloudinaryFolders.tsR1-R24](diffhunk://#diff-54fb3971e79455459ad66e0af0267d60024438321e521c0dc8dd91d659f40d07R1-R24)`)
* Added a robust utility function `getCloudinaryFolderPaths` in `cloudinary.ts` to fetch, normalize, deduplicate, and paginate folder paths from Cloudinary's API. (`[[1]](diffhunk://#diff-c9eaa44e4dfdd7a53aa2bc364bb68d6ff7b7c563c3489f7a80b62e30bbff8695R14-R22)`, `[[2]](diffhunk://#diff-c9eaa44e4dfdd7a53aa2bc364bb68d6ff7b7c563c3489f7a80b62e30bbff8695R54-R101)`)
* Registered the new endpoint in Payload's configuration. (`[[1]](diffhunk://#diff-f6b6f316a2640772c82fc212b5863ca4bf1139a256e8f4e1ef0145e1ac66daefR20)`, `[[2]](diffhunk://#diff-f6b6f316a2640772c82fc212b5863ca4bf1139a256e8f4e1ef0145e1ac66daefL39-R53)`)

**Testing & Reliability:**

* Added comprehensive integration tests for the folder picker UI (`cloudinary-folder-field.int.spec.tsx`), the backend endpoint (`cloudinary-folders-endpoint.int.spec.ts`), and the Cloudinary utility (`cloudinary.int.spec.ts`). (`[[1]](diffhunk://#diff-663d1a5a8fcb4ecdd0f40accb024543f40a30363464c88859260e86ffa60673dR1-R143)`, `[[2]](diffhunk://#diff-c3d9994dfdf14833194bc420c1ae3fcf57bd834bb476d7451dfd9820fa859f70R1-R60)`, `[[3]](diffhunk://#diff-2011fa38a572ddfa6ce9ccb9d8b88b7fdd713a5dc272d2241caf551321085c96R1-R80)`)
* Updated Vitest configuration to include `.tsx` files in integration tests. (`[vitest.config.mtsL10-R10](diffhunk://#diff-2988e37334fe90f690078d3a20744a1aaae079bd9bb1ce557a3add080dd89141L10-R10)`)