### PR TITLE
update homepage

### DIFF
--- a/src/app/(frontend)/[locale]/page.tsx
+++ b/src/app/(frontend)/[locale]/page.tsx
@@ -4,6 +4,9 @@ import BlockRenderer from '@/components/BlockRenderer'
 import { SetSlug } from '@/components/SlugProvider'
 import config from '@/payload.config'
 
+// The home page is managed in Payload and must reflect published edits immediately.
+export const dynamic = 'force-dynamic'
+
 export default async function HomePage(props: { params: Promise<{ locale: string }> }) {
   const { locale } = await props.params
   const payloadConfig = await config


### PR DESCRIPTION
This pull request makes a small but important configuration change to the home page. The page is now set to always render dynamically, ensuring that published edits in Payload are reflected immediately.

* The `dynamic` export is set to `'force-dynamic'` in `src/app/(frontend)/[locale]/page.tsx`, so the home page always shows the latest published content. ([src/app/(frontend)/[locale]/page.tsxR7-R9](diffhunk://#diff-ef84f6b8a72eef9ea7224ca70bb0dc5ef48bfdc31e37bbe922390509ff20d182R7-R9))